### PR TITLE
add select optgroup

### DIFF
--- a/src/Forms/Elements/Select.php
+++ b/src/Forms/Elements/Select.php
@@ -29,11 +29,24 @@ class Select extends AbstractElement {
 		return sprintf('<option %s>%s</option>', implode(' ', $pairs), $value).PHP_EOL;
 	}
 
+	protected function getHtmlOptionGroup($key, $list)
+    {
+        $html = '';
+
+        foreach ($list as $label => $value) {
+            $html .= $this->getHtmlOption($label, $value, ($this->getValue() == $label));
+        }
+
+        return sprintf('<optgroup label="%s">%s</optgroup>', $key, $html).PHP_EOL;
+    }
+
 	protected function getHtmlOptions() {
 		$html = '';
 
 		foreach($this->options as $key => $value) {
-			$html .= $this->getHtmlOption($key, $value, ($this->getValue() == $key));
+			$html .= is_array($value) ?
+				$this->getHtmlOptionGroup($key, $value) :
+				$this->getHtmlOption($key, $value, ($this->getValue() == $key));
 		}
 
 		return $html;


### PR DESCRIPTION
Add support for `<optgroup>`

Example data:

```php
$timezones = [
	'Africa' => [
		'Africa/Abidjan' => 'Abidjan - 08:19',
		'Africa/Accra' => 'Accra - 08:19',
		'Africa/Addis_Ababa' => 'Addis_Ababa - 11:19',
	],
	'America' => [
		'America/Adak' => 'Adak - 22:19 (10:19 pm)',
		'America/Anchorage' => 'Anchorage - 23:19 (11:19 pm)',
		'America/Anguilla' => 'Anguilla - 04:19',
	],
	'Antarctica' => [
		'Antarctica/Casey' => 'Casey - 16:19 (4:19 pm)',
		'Antarctica/Davis' => 'Davis - 15:19 (3:19 pm)',
		'Antarctica/DumontDUrville' => 'DumontDUrville - 18:19 (6:19 pm)',
	],
	'Aisa' => [
		'Asia/Aden' => 'Aden - 11:19',
		'Asia/Almaty' => 'Almaty - 14:19 (2:19 pm)',
		'Asia/Amman' => 'Amman - 10:19',
	],
	'Atlantic' => [
		'Atlantic/Azores' => 'Azores - 07:19',
		'Atlantic/Bermuda' => 'Bermuda - 04:19',
		'Atlantic/Canary' => 'Canary - 08:19',
	],
	'Europe' => [
		'Europe/Amsterdam' => 'Amsterdam - 09:19',
		'Europe/Andorra' => 'Andorra - 09:19',
		'Europe/Athens' => 'Athens - 10:19',
	],
	'Indian' => [
		'Indian/Antananarivo' => 'Antananarivo - 11:19',
		'Indian/Chagos' => 'Chagos - 14:19 (2:19 pm)',
		'Indian/Christmas' => 'Christmas - 15:19 (3:19 pm)',
	],
	'Pacific' => [
		'Pacific/Apia' => 'Apia - 22:19 (10:19 pm)',
		'Pacific/Auckland' => 'Auckland - 21:19 (9:19 pm)',
		'Pacific/Bougainville' => 'Bougainville - 19:19 (7:19 pm)',
	],
];

$form->addElement(new \Forms\Elements\Select('timezone', [
	'label' => 'Timezone',
	'value' => 'Europe/Amsterdam',
	'options' => $timezones
]));
```